### PR TITLE
Verification List: Unknown -> Other

### DIFF
--- a/FINGERPRINT_Toolbox_Verification_List.adoc
+++ b/FINGERPRINT_Toolbox_Verification_List.adoc
@@ -11,7 +11,7 @@ This shows the set of attacks and applicability based on the sensor type used fo
 |Attack Description
 |Optical Sensor
 |Conductive Sensor
-|Unknown
+|Other
 
 |link:attacks/01-01-Fingerprint-attack.adoc[Fingerprint 01-01]
 |Non-Newtonian fluid cast from Transparency mold


### PR DESCRIPTION
Vendor should need to let the evaluator know the TOE sensor technology, so "Unknown" shouldn't be possible. Should a number of "other" sensors be evaluated, the BIO-iTC likely needs to revise the toolbox.