### PR TITLE
editing copper thickness

### DIFF
--- a/FINGERPRINT_Toolbox_Inventory.adoc
+++ b/FINGERPRINT_Toolbox_Inventory.adoc
@@ -236,7 +236,9 @@ a|
 a|Printed circuit board
 
 * Hobbyist grade is sufficient
-* Copper cladding shall be of “2 oz.” thickness or approximately 2.74 mils thick
+* Epoxy laminates should have copper cladding thicknesses that correspond to one of the following:
+** 35 μm = 1.38 mils = "1 oz" of copper
+** 70 μm = 2.75 mils = "2 oz" of copper
 * Substrate shall be at least 1.6 mm thick
 a|
 

--- a/attacks/02-01-Fingerprint_attack.adoc
+++ b/attacks/02-01-Fingerprint_attack.adoc
@@ -53,7 +53,7 @@ The evaluator should consider changing the following factors for penetration tes
 * Configuration of tools and materials
 +
 The evaluator may, for example, vary the temperature of the PAIs to change the stiffness of the friction ridges. Different non-Newtonian fluid manufactures may be used.
-
++
 Copper cladding thickness can be varied to produce differing height ridges in the casts.
 
 * Presentation method

--- a/attacks/02-02-Fingerprint_attack.adoc
+++ b/attacks/02-02-Fingerprint_attack.adoc
@@ -55,7 +55,7 @@ The evaluator should consider changing the following factors for penetration tes
 * Configuration of tools and materials
 +
 The evaluator may, for example, vary the temperature of the PAIs to change the stiffness of the friction ridges. Different modeling compound manufactures may be used. The PAIs may be allowed to dry for a short time before being presented to the TOE. If commercial compound is used, different colors may be procured. The literature shows different presentation attack performance can be achieved with different colors.
-
++
 Copper cladding thickness can be varied to produce differing height ridges in the casts.
 
 * Presentation method

--- a/attacks/02-03-Fingerprint_attack.adoc
+++ b/attacks/02-03-Fingerprint_attack.adoc
@@ -57,7 +57,7 @@ The evaluator should consider changing the following factors for penetration tes
 * Configuration of tools and materials
 +
 The evaluator may, for example, vary the temperature of the PAIs to change the stiffness of the friction ridges. Gelatins from different manufactures may be used. Different bloom hardness gelatins may be used. The gelatin / glycerin / water ratio may be varied.
-
++
 Copper cladding thickness can be varied to produce differing height ridges in the casts.
 
 * Presentation method

--- a/attacks/02-04-Fingerprint_attack.adoc
+++ b/attacks/02-04-Fingerprint_attack.adoc
@@ -56,7 +56,7 @@ The evaluator should consider changing the following factors for penetration tes
 * Configuration of tools and materials
 +
 The evaluator may, for example, vary the temperature of the PAIs to change the stiffness of the friction ridges. Different silicone manufactures may be used. The Shore hardness ratings can be varied within the approximate range listed. PAI optical clarity may be varied by using different silicones.
-
++
 Copper cladding thickness can be varied to produce differing height ridges in the casts.
 
 * Presentation method


### PR DESCRIPTION
I have added updated text in the inventory to specifically state the board should have either the 1oz or 2oz sizes (using all three thickness measures).

I didn't change the text in the attack since I expect that making it clear in the inventory should cover the choices.

I edited the text to bring the one line into proper alignment in the attacks (4 of 5 needed it)

This should close #12