### PR TITLE
CSM 2/3 Relief description

### DIFF
--- a/FINGERPRINT_Toolbox_Overview.adoc
+++ b/FINGERPRINT_Toolbox_Overview.adoc
@@ -53,7 +53,7 @@ Printed circuit boards come in varying substrate and copper cladding thicknesses
 
 ====== Laser-printed transparency
 
-Molds made from laser-printed overhead transparency material are similar to PCB molds. They are easier, cheaper, and faster to make than PCB molds. However, a smaller relief (i.e., a lower degree of depth) between the PAI ridges and valleys will be generated than with PCBs.
+Molds made from laser-printed overhead transparency material are similar to PCB molds. They are easier, cheaper, and faster to make than PCB molds. However, a smaller relief (i.e., a lower degree of depth) between the PAI ridges and valleys will be noticed when compared to equivalent PCB molds.
 
 === Curved Attacks
 

--- a/FINGERPRINT_Toolbox_Overview.adoc
+++ b/FINGERPRINT_Toolbox_Overview.adoc
@@ -49,11 +49,11 @@ Molds that are flat produce flat PAIs. Genuine fingers are not flat. This does n
 
 ====== Printed Circuit Board (PCB)
 
-Printed circuit boards come in varying substrate and copper cladding thicknesses. The substrate thickness should be thick enough to allow easy handling and prevent noticeable flexing of the PCB. A thickness of 1.6 mm is typical and sufficient for PAD testing applications. A common substrate material used in PCBs is designated FR4 or fiberglass reinforced epoxy. The copper cladding should be 2.74 mils thick, referred to as “2 oz. of copper” in the PCB manufacturing industry. This is twice the standard PCB trace thickness of “1 oz. of copper”. The thicker copper traces provide greater relief (i.e., a higher degree of depth) between the PAI ridges and valleys.
+Printed circuit boards come in varying substrate and copper cladding thicknesses. The substrate thickness should be thick enough to allow easy handling and prevent noticeable flexing of the PCB. A thickness of 1.6 mm is typical and sufficient for PAD testing applications. A common substrate material used in PCBs is designated FR4 or fiberglass reinforced epoxy. The copper cladding should be 2.74 mils thick, referred to as “2 oz. of copper” in the PCB manufacturing industry. This is twice the standard PCB trace thickness of “1 oz. of copper”. The thicker copper traces provide a greater relief (i.e., a higher degree of depth) between the PAI ridges and valleys.
 
 ====== Laser-printed transparency
 
-Molds made from laser-printed overhead transparency material are similar to PCB molds. They are easier, cheaper, and faster to make than PCB molds. However, a smaller relief (i.e., a lower degree of depth) between the PAI ridges and valleys will generated than with PCBs.
+Molds made from laser-printed overhead transparency material are similar to PCB molds. They are easier, cheaper, and faster to make than PCB molds. However, a smaller relief (i.e., a lower degree of depth) between the PAI ridges and valleys will be generated than with PCBs.
 
 === Curved Attacks
 

--- a/FINGERPRINT_Toolbox_Overview.adoc
+++ b/FINGERPRINT_Toolbox_Overview.adoc
@@ -49,7 +49,7 @@ Molds that are flat produce flat PAIs. Genuine fingers are not flat. This does n
 
 ====== Printed Circuit Board (PCB)
 
-Printed circuit boards come in varying substrate and copper cladding thicknesses. The substrate thickness should be thick enough to allow easy handling and prevent noticeable flexing of the PCB. A thickness of 1.6 mm is typical and sufficient for PAD testing applications. A common substrate material used in PCBs is designated FR4 or fiberglass reinforced epoxy. The copper cladding should be 2.74 mils thick, referred to as “2 oz. of copper” in the PCB manufacturing industry. This is twice the standard PCB trace thickness of “1 oz. of copper”. The thicker copper traces provide greater relief (a higher degree of depth) between the PAI ridges and valleys.
+Printed circuit boards come in varying substrate and copper cladding thicknesses. The substrate thickness should be thick enough to allow easy handling and prevent noticeable flexing of the PCB. A thickness of 1.6 mm is typical and sufficient for PAD testing applications. A common substrate material used in PCBs is designated FR4 or fiberglass reinforced epoxy. The copper cladding should be 2.74 mils thick, referred to as “2 oz. of copper” in the PCB manufacturing industry. This is twice the standard PCB trace thickness of “1 oz. of copper”. The thicker copper traces provide greater relief (i.e., a higher degree of depth) between the PAI ridges and valleys.
 
 ====== Laser-printed transparency
 

--- a/FINGERPRINT_Toolbox_Overview.adoc
+++ b/FINGERPRINT_Toolbox_Overview.adoc
@@ -49,11 +49,11 @@ Molds that are flat produce flat PAIs. Genuine fingers are not flat. This does n
 
 ====== Printed Circuit Board (PCB)
 
-Printed circuit boards come in varying substrate and copper cladding thicknesses. The substrate thickness should be thick enough to allow easy handling and prevent noticeable flexing of the PCB. A thickness of 1.6 mm is typical and sufficient for PAD testing applications. A common substrate material used in PCBs is designated FR4 or fiberglass reinforced epoxy. The copper cladding should be 2.74 mils thick, referred to as “2 oz. of copper” in the PCB manufacturing industry. This is twice the standard PCB trace thickness of “1 oz. of copper”. The thicker copper traces provide greater relief between the PAI ridges and valleys.
+Printed circuit boards come in varying substrate and copper cladding thicknesses. The substrate thickness should be thick enough to allow easy handling and prevent noticeable flexing of the PCB. A thickness of 1.6 mm is typical and sufficient for PAD testing applications. A common substrate material used in PCBs is designated FR4 or fiberglass reinforced epoxy. The copper cladding should be 2.74 mils thick, referred to as “2 oz. of copper” in the PCB manufacturing industry. This is twice the standard PCB trace thickness of “1 oz. of copper”. The thicker copper traces provide greater relief (a higher degree of depth) between the PAI ridges and valleys.
 
 ====== Laser-printed transparency
 
-Molds made from laser-printed overhead transparency material are similar to PCB molds. They are easier, cheaper, and faster to make than PCB molds. However, the relief between the PAI ridges and valleys will be much smaller than with PCBs.
+Molds made from laser-printed overhead transparency material are similar to PCB molds. They are easier, cheaper, and faster to make than PCB molds. However, a smaller relief (a lower degree of depth) between the PAI ridges and valleys will generated than with PCBs.
 
 === Curved Attacks
 

--- a/FINGERPRINT_Toolbox_Overview.adoc
+++ b/FINGERPRINT_Toolbox_Overview.adoc
@@ -53,7 +53,7 @@ Printed circuit boards come in varying substrate and copper cladding thicknesses
 
 ====== Laser-printed transparency
 
-Molds made from laser-printed overhead transparency material are similar to PCB molds. They are easier, cheaper, and faster to make than PCB molds. However, a smaller relief (a lower degree of depth) between the PAI ridges and valleys will generated than with PCBs.
+Molds made from laser-printed overhead transparency material are similar to PCB molds. They are easier, cheaper, and faster to make than PCB molds. However, a smaller relief (i.e., a lower degree of depth) between the PAI ridges and valleys will generated than with PCBs.
 
 === Curved Attacks
 


### PR DESCRIPTION
CSM 2: ”. The thicker copper traces provide greater relief between the PAI ridges and valleys. - greater relief" - This statement seems not fully understood and suggest to provide better clarification.

Proposal: Does greater mean the higher degree of depth between the ridges and valley ?

CSM 3: "However, the relief between the PAI ridges and valleys will be much smaller than with PCBs" - This statement seems not fully understood and suggest to provide better clarification.

Proposal: Does smaller mean the lower degree of depth between the ridges and valley ?

From spreadsheet (combined due to common topic)